### PR TITLE
Pin github workflows to a commit hash instead of version tag for security purpose

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -6,8 +6,8 @@ jobs:
   combine-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: maadhattah/combine-dependabot-prs@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: maadhattah/combine-dependabot-prs@aecc949b306f1ca346aa2e96729eb652f9797ca7 # main
         with:
           branchPrefix: "dependabot"
           mustBeGreen: true


### PR DESCRIPTION
This PR pins Github workflows to a specific commit hash instead of version tag, for security purpose.

By pinning Github workflows to a specific commit hash, we should be able to restrict deployment of potentially compromised Github actions in the future. If you have any questions, please reach out to #sec-team-appsec.

Note: If you ever need to manually look up the commit hash for a given action version (tag), you can run:

    git ls-remote https://github.com/<owner>/<repo>.git <tag>

Replace `<owner>`, `<repo>`, and `<tag>` with the appropriate values (for example, `actions/checkout` and `v3`). The output will show the commit SHA corresponding to the tag. Use that SHA in your workflow file, e.g.:

    uses: actions/checkout@<sha> # <tag version>
